### PR TITLE
Update Convert.php to include changes made to finalName

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ php convert.php
     "previewPath": "output\/c0096728-3490-4f5f-96a8-0f20a5a1244c\/file\/index.html",
     "downloadPath": "output\/c0096728-3490-4f5f-96a8-0f20a5a1244c\/file.zip"
 }
-http://localhost:8080/microservice-example/output/c0096728-3490-4f5f-96a8-0f20a5a1244c/file/index.html
+http://localhost:8080/buildvu-microservice/output/c0096728-3490-4f5f-96a8-0f20a5a1244c/file/index.html
 ```
 
 ## Hosted Script ##
@@ -190,7 +190,7 @@ In this case, the Apache server is deployed at localhost:80. To execute the scri
 
 The webpage will display the link to the preview:
 
-```http://localhost:8080/microservice-example/output/c0096728-3490-4f5f-96a8-0f20a5a1244c/file/index.html```
+```http://localhost:8080/buildvu-microservice/output/c0096728-3490-4f5f-96a8-0f20a5a1244c/file/index.html```
 
 The downloaded zip will be available in ```htdocs/conversion/output```.
 

--- a/tests/Convert.php
+++ b/tests/Convert.php
@@ -4,7 +4,7 @@ require_once __DIR__ . "/../vendor/autoload.php";
 
 use IDRsolutions\BuildVuPhpClient\Converter;
 
-$endpoint = "http://localhost:8080/microservice-example/";
+$endpoint = "http://localhost:8080/buildvu-microservice/";
 
 /* Set up the conversion options */
 


### PR DESCRIPTION
Changed endpoint to buildvu-microservice, this is due to the changes to the finalName in the pom.xml in buildvu-microservice-example